### PR TITLE
Down with Disease Updates

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,5 +5,8 @@
 - Upgraded dependencies to latest versions
 - Updated to Android 31
 - Fixed back stack icon being the incorrect icon. Is now the same as the launcher icon.
+- Add 5 Seconds timeout to all network calls [#26](https://github.com/AndrewReitz/never-ending-splendor/issues/26)
+- Update to phish.net api version 5
+- Wrapped image downloading in try catch to ensure it won't crash the app if an image can't be downloaded.
 
 == Carini 2/12/2022

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 kotlin = "1.6.10"
-firebase = "29.2.0"
+firebase = "30.0.2"
 androidx-media2 = "1.2.1"
 kodein = "7.11.0"
-flipper = "0.138.0"
-okhttp = "5.0.0-alpha.2"
+flipper = "0.146.0"
+okhttp = "5.0.0-alpha.7"
 moshi = "1.13.0"
 retrofit = "2.9.0"
-coroutines = "1.6.0"
+coroutines = "1.6.1"
 compose = "1.1.1"
 
 [libraries]
-android-build-gradle = { module = "com.android.tools.build:gradle", version = "7.1.2"}
+android-build-gradle = { module = "com.android.tools.build:gradle", version = "7.2.0"}
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin"}
 kotlin-poet = { module = "com.squareup:kotlinpoet", version = "1.8.0" }
 
@@ -20,24 +20,23 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 
 play-services-cast = { module = "com.google.android.gms:play-services-cast", version = "21.0.1" }
 play-services-cast-companion = { module = "com.google.android.libraries.cast.companionlibrary:ccl", version = "2.9.1" }
-android-material = { module = "com.google.android.material:material", version = "1.5.0" }
+android-material = { module = "com.google.android.material:material", version = "1.6.0" }
 
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.7.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.4.1" }
 androidx-cardview = { module = "androidx.cardview:cardview", version = "1.0.0" }
-androidx-mediarouter = { module = "androidx.mediarouter:mediarouter", version = "1.2.6" }
+androidx-mediarouter = { module = "androidx.mediarouter:mediarouter", version = "1.3.0" }
 androidx-media2-session = { module = "androidx.media2:media2-session", version.ref = "androidx-media2" }
 androidx-media2-widget = { module = "androidx.media2:media2-widget", version.ref = "androidx-media2" }
 androidx-media2-player = { module = "androidx.media2:media2-player", version.ref = "androidx-media2" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.3" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.4" }
 
 kodein = { module = "org.kodein.di:kodein-di", version.ref = "kodein" }
 kodein-android = { module = "org.kodein.di:kodein-di-framework-android-x", version.ref = "kodein" }
 
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
-# todo update to version ref when upgraded
-okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version = "4.9.3" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }
 flipper-leakcanary = { module = "com.facebook.flipper:flipper-leakcanary2-plugin", version.ref = "flipper" }
@@ -48,15 +47,15 @@ facebook-soloader = { module = "com.facebook.soloader:soloader", version = "0.10
 
 junit = { module = "junit:junit", version = "4.13.2"}
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
-mockito = { module = "org.mockito:mockito-core", version = "4.4.0"}
+mockito = { module = "org.mockito:mockito-core", version = "4.5.1"}
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.0.0"}
 
-result4k = { module = "dev.forkhandles:result4k", version = "2.0.0.0" }
+result4k = { module = "dev.forkhandles:result4k", version = "2.1.1.0" }
 byteunits = { module = "com.jakewharton.byteunits:byteunits", version = "0.9.1" }
 picasso = { module = "com.squareup.picasso:picasso", version = "2.71828" }
 timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version = "2.8.1" }
-okio = { module = "com.squareup.okio:okio", version = "3.0.0" }
+leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version = "2.9.1" }
+okio = { module = "com.squareup.okio:okio", version = "3.1.0" }
 
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mobile/src/main/java/never/ending/splendor/app/utils/Images.kt
+++ b/mobile/src/main/java/never/ending/splendor/app/utils/Images.kt
@@ -1,6 +1,7 @@
 package never.ending.splendor.app.utils
 
 import com.squareup.picasso.Picasso
+import timber.log.Timber
 
 class Images(private val picasso: Picasso) {
 
@@ -74,7 +75,11 @@ class Images(private val picasso: Picasso) {
     init {
         // prefetch all images
         images.forEach {
-            picasso.load(it).fetch()
+            runCatching {
+                picasso.load(it).fetch()
+            }.onFailure {
+                Timber.e(it, "Error loading an image")
+            }
         }
     }
 

--- a/networking/src/main/kotlin/nes/networking/networkingModule.kt
+++ b/networking/src/main/kotlin/nes/networking/networkingModule.kt
@@ -15,7 +15,9 @@ import org.kodein.di.bindSet
 import org.kodein.di.instance
 import org.kodein.di.singleton
 import java.io.File
+import java.time.Duration
 import java.util.Date
+import java.util.concurrent.TimeUnit
 
 /**
  * Tag for networking module to provide the cache directory for http client
@@ -39,6 +41,7 @@ val networkingModule = DI.Module(name = "NetworkingModule") {
     bind<OkHttpClient>() with singleton {
         OkHttpClient.Builder()
             .cache(Cache(File(instance<File>(tag = CACHE_DIR_TAG), "http"), DISK_CACHE_SIZE.toLong()))
+            .callTimeout(3, TimeUnit.SECONDS)
             .apply { instance<Set<Interceptor>>().forEach { addInterceptor(it) } }
             .build()
     }

--- a/networking/src/main/kotlin/nes/networking/phishnet/PhishNetService.kt
+++ b/networking/src/main/kotlin/nes/networking/phishnet/PhishNetService.kt
@@ -4,11 +4,12 @@ import nes.networking.phishnet.model.PhishNetWrapper
 import nes.networking.phishnet.model.Review
 import nes.networking.phishnet.model.SetList
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface PhishNetService {
-    @GET("setlists/get")
-    suspend fun setlist(@Query("showdate") showDate: String): PhishNetWrapper<SetList>
+    @GET("setlists/showdate/{showDate}")
+    suspend fun setlist(@Path("showdate") showDate: String): PhishNetWrapper<SetList>
 
     @GET("reviews/query")
     suspend fun reviews(@Query("showid") showId: String): PhishNetWrapper<Review>

--- a/networking/src/main/kotlin/nes/networking/phishnet/phishNetModule.kt
+++ b/networking/src/main/kotlin/nes/networking/phishnet/phishNetModule.kt
@@ -12,7 +12,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 
 const val PHISH_NET_RETROFIT_TAG = "phish.net"
 
-private val PHISH_NET_API_URL: HttpUrl = requireNotNull("https://api.phish.net/v3/".toHttpUrlOrNull())
+private val PHISH_NET_API_URL: HttpUrl = requireNotNull("https://api.phish.net/v5/".toHttpUrlOrNull())
 
 val phishNetModule = DI.Module(name = "PhishNetModule") {
     bind<PhishNetApiKey>() with singleton {


### PR DESCRIPTION
- Upgraded dependencies to latest versions
- Add 5 Seconds timeout to all network calls #26
- Update to phish.net api version 5 #28
- Wrapped image downloading in try catch to ensure it won't crash the app if an image can't be downloaded.