### PR TITLE
Fix Picasso Crash

### DIFF
--- a/mobile/src/main/java/never/ending/splendor/app/utils/picasso.kt
+++ b/mobile/src/main/java/never/ending/splendor/app/utils/picasso.kt
@@ -43,7 +43,7 @@ private suspend fun Picasso.loadImage(url: String, maxWidth: Int, maxHeight: Int
                     continuation.resume(bitmap)
                 }
 
-                override fun onBitmapFailed(e: Exception, errorDrawable: Drawable) {
+                override fun onBitmapFailed(e: Exception, errorDrawable: Drawable?) {
                     continuation.resumeWithException(e)
                 }
             })
@@ -52,5 +52,5 @@ private suspend fun Picasso.loadImage(url: String, maxWidth: Int, maxHeight: Int
 
 abstract class SimpleTarget : Target {
     override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
-    override fun onBitmapFailed(e: Exception, errorDrawable: Drawable) {}
+    override fun onBitmapFailed(e: Exception, errorDrawable: Drawable?) {}
 }


### PR DESCRIPTION
Issue is with kotlin overriding a java method that can return nullable
platform type and in kotlin it was set to not-null causing kotlin
to throw an exception when a null value was passed.