### PR TITLE
Fix Media Player Null Crash

### DIFF
--- a/mobile/src/main/java/never/ending/splendor/app/playback/LocalPlayback.kt
+++ b/mobile/src/main/java/never/ending/splendor/app/playback/LocalPlayback.kt
@@ -116,7 +116,7 @@ class LocalPlayback(
         get() = if (_mediaPlayer != null) mediaPlayer.currentPosition else field
 
     override fun updateLastKnownStreamPosition() {
-        currentPosition = mediaPlayer.currentPosition
+        currentPosition = if(_mediaPlayer != null) mediaPlayer.currentPosition else 0
     }
 
     override fun playNext(item: MediaSessionCompat.QueueItem): Boolean {


### PR DESCRIPTION
Reports from google play say that this occurs on certain devices during the pre-launch check.